### PR TITLE
support blank keywords and handle empty subtitle path

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ services:
       "eng":"English"}'
 
       SYNC_KEYWORDS: '["sync", "out of sync", "messed up", "synchronization"]' # Replace with your actual sync keywords
-      
+      #SYNC_KEYWORDS: "" #Alternatively set any keywords (even a blank description) to initiate a sync
+
       restart: unless-stopped
 ```
    

--- a/functions/Contains-SyncKeyword.ps1
+++ b/functions/Contains-SyncKeyword.ps1
@@ -1,10 +1,15 @@
 function Contains-SyncKeyword {
     param ([string]$issueMessage, [array]$syncKeywords)
-    $lowercaseMessage = $issueMessage.ToLower()
-    foreach ($keyword in $syncKeywords) {
-        if ($lowercaseMessage.Contains($keyword)) {
-            return $true
-        }
+    if ($syncKeywords.Length -eq 0) {
+        return $true
     }
-    return $false
+    else {
+        $lowercaseMessage = $issueMessage.ToLower()
+        foreach ($keyword in $syncKeywords) {
+            if ($lowercaseMessage.Contains($keyword)) {
+                return $true
+            }
+        }
+        return $false
+    }
 }

--- a/functions/Get-BazarrEpisodeSubtitlePath.ps1
+++ b/functions/Get-BazarrEpisodeSubtitlePath.ps1
@@ -5,8 +5,10 @@ function Get-BazarrEpisodeSubtitlePath {
         $response = Invoke-RestMethod -Uri $url -Method Get
         foreach ($episode in $response.data) {
             foreach ($subtitle in $episode.subtitles) {
-                if ($subtitle.name -eq $languageName -and $subtitle.hi -eq $hearingImpaired) {
-                    return $subtitle.path
+                if ($subtitle.name -eq $languageName -and $subtitle.path) {
+                    if ($subtitle.hi -eq $hearingImpaired -or -not $hearingImpaired) {
+                        return $subtitle.path
+                    }
                 }
             }
         }

--- a/functions/Get-BazarrMovieSubtitlePath.ps1
+++ b/functions/Get-BazarrMovieSubtitlePath.ps1
@@ -5,8 +5,10 @@ function Get-BazarrMovieSubtitlePath {
         $response = Invoke-RestMethod -Uri $url -Method Get
         foreach ($movie in $response.data) {
             foreach ($subtitle in $movie.subtitles) {
-                if ($subtitle.name -eq $languageName -and $subtitle.hi -eq $hearingImpaired) {
-                    return $subtitle.path
+                if ($subtitle.name -eq $languageName -and $subtitle.path) {
+                    if ($subtitle.hi -eq $hearingImpaired -or -not $hearingImpaired) {
+                        return $subtitle.path
+                    }
                 }
             }
         }

--- a/functions/Map-LanguageCode.ps1
+++ b/functions/Map-LanguageCode.ps1
@@ -1,4 +1,14 @@
 function Map-LanguageCode {
     param ([string]$languageCode, [hashtable]$languageMap)
-    return $languageMap[$languageCode]
+    if (-not $languageCode) {
+        if ($languageMap.count -eq 1) {
+            return $($languageMap.Values)
+        }
+        else {
+            return $($languageMap.Values)[0]
+        }
+    }
+    else {
+        return $languageMap[$languageCode]
+    }
 }

--- a/overr-syncerr-main.ps1
+++ b/overr-syncerr-main.ps1
@@ -39,12 +39,18 @@ try {
     Write-Host "Error parsing language map: $_"
 }
 
-try {
-    $syncKeywords = ConvertFrom-Json -InputObject $syncKeywordsJson
-    Write-Host "Sync keywords parsed successfully"
-} catch {
-    $syncKeywords = @('sync', 'out of sync', 'synchronize', 'synchronization')
-    Write-Host "Error parsing sync keywords: $_"
+if (-not $syncKeywordsJson) {
+    try {
+        $syncKeywords = ConvertFrom-Json -InputObject $syncKeywordsJson
+        Write-Host "Sync keywords parsed successfully"
+    } catch {
+        $syncKeywords = @('sync', 'out of sync', 'synchronize', 'synchronization')
+        Write-Host "Error parsing sync keywords: $_"
+    }
+}
+else {
+    $syncKeywords = @("")
+    Write-Host "Sync keywords disabled"
 }
 
 # Fetch Plex Library IDs


### PR DESCRIPTION
Hi, I like this project but found it frustrating to have to enter a description in order to get a sync initiated. Since I only deal with one language (English) and do not use hearing impaired subtitles it is far faster to just submit a blank description from Overseerrr to force a sync 

Note I run a custom Overseerr locally that supports submitting an empty issue description but plan to submit a PR to Overseerr to support this as well...however this should still be beneficial since it would allow any entered description to initiate a sync (like just spaces or even gibberish although I haven't actually tried).

I tried to write all of these changes such that they do not alter the original functionality.

This PR does a few things:
1. Checks for `SYNC_KEYWORDS: ""` and if found, will always return true from the `Contains-SyncKeyword` function
2. Returns the first language mapping if an empty request message is submitted 
3. Ignores hearing impaired verification if not found in the request message

Additionally, I found that if you have embedded subtitles enabled in Bazarr, `Get-BazarrEpisodeSubtitlePath.ps1` and `Get-BazarrMovieSubtitlePath.ps1` would return these which do not have a valid path. Therefore I added a verification to ensure the returned subtitle has a path defined.